### PR TITLE
Wrong path for controller dir (plural used)

### DIFF
--- a/get-started/the-dispatcher.md
+++ b/get-started/the-dispatcher.md
@@ -67,7 +67,7 @@ We need to our dashboard controller to extend [`ComKoowaControllerView`](http://
 
 We create the file
 
-`/administrator/components/com_todo/controllers/dashboard.php`
+`/administrator/components/com_todo/controller/dashboard.php`
 
 And add the following code
 


### PR DESCRIPTION
Controller directory should always be singular per naming convention, but the path proposed is in the plural, which breaks the code.