### PR TITLE
Missing PHP opening tag in ComTodoDatabaseTableItems code

### DIFF
--- a/get-started/add-toolbar-to-item-view.md
+++ b/get-started/add-toolbar-to-item-view.md
@@ -55,6 +55,7 @@ Just create the following file
 And add the following code
 
 ```php
+<?php
 class ComTodoDatabaseTableItems extends KDatabaseTableAbstract
 {
     protected function _initialize(KObjectConfig $config)


### PR DESCRIPTION
If you just copy/paste the code from the guide, you will get RuntimeExceptions because autoloader cannot find the class. Adding opening PHP tag fixes that.